### PR TITLE
set response=True for `write_gatt_char` to fix silent failure

### DIFF
--- a/pycycling/fitness_machine_service.py
+++ b/pycycling/fitness_machine_service.py
@@ -198,7 +198,7 @@ class FitnessMachineService:
     async def reset(self) -> None:
         message = form_ftms_control_command(FTMSControlPointOpCode.RESET)
         await self._client.write_gatt_char(
-            ftms_fitness_machine_control_point_characteristic_id, message, False
+            ftms_fitness_machine_control_point_characteristic_id, message, True
         )
 
     async def set_target_resistance_level(self, level: int) -> None:
@@ -206,7 +206,7 @@ class FitnessMachineService:
             FTMSControlPointOpCode.SET_TARGET_RESISTANCE_LEVEL, int(level)
         )
         await self._client.write_gatt_char(
-            ftms_fitness_machine_control_point_characteristic_id, message, False
+            ftms_fitness_machine_control_point_characteristic_id, message, True
         )
 
     async def set_target_power(self, power: int) -> None:
@@ -214,5 +214,5 @@ class FitnessMachineService:
             FTMSControlPointOpCode.SET_TARGET_POWER, int(power)
         )
         await self._client.write_gatt_char(
-            ftms_fitness_machine_control_point_characteristic_id, message, False
+            ftms_fitness_machine_control_point_characteristic_id, message, True
         )

--- a/pycycling/fitness_machine_service.py
+++ b/pycycling/fitness_machine_service.py
@@ -192,7 +192,7 @@ class FitnessMachineService:
     async def request_control(self) -> None:
         message = form_ftms_control_command(FTMSControlPointOpCode.REQUEST_CONTROL)
         await self._client.write_gatt_char(
-            ftms_fitness_machine_control_point_characteristic_id, message, False
+            ftms_fitness_machine_control_point_characteristic_id, message, True
         )
 
     async def reset(self) -> None:


### PR DESCRIPTION
I was testing FTMS on my Elite Suito T smart trainer and the resistance wasn't changing using the example script.

I found that setting `response=True` for [bleak's `write_gatt_char`](https://bleak.readthedocs.io/en/latest/backends/linux.html?highlight=write_gatt#bleak.backends.bluezdbus.client.BleakClientBlueZDBus.write_gatt_char) fixed it.

[Huawei docs](https://developer.huawei.com/consumer/en/doc/HMSCore-Guides/fmcp-0000001050147089) says "When the phone request the control of a fitness machine, the fitness machine needs to respond with 0x80...". I'm guessing 'needs' here means that the request itself needs to be a "Write with response" type.

I'm not sure why it worked before when `response=False`.