### PR TITLE
Fixes #48

### DIFF
--- a/examples/fitness_machine_service_example.py
+++ b/examples/fitness_machine_service_example.py
@@ -9,7 +9,12 @@ async def run(address):
         # Print 'read' characteristics
 
         ### Fitness Machine Features
-        fitness_machine_features, target_setting_features = await ftms.get_fitness_machine_feature()
+        fitness_machine_features, target_setting_features = await ftms.get_all_features()
+
+        # backward compatible
+        fitness_machine_features = await ftms.get_fitness_machine_feature()
+        target_setting_features = await ftms.get_target_setting_feature()
+
         fitness_machine_features = fitness_machine_features._asdict()
         target_setting_features = target_setting_features._asdict()
 

--- a/pycycling/fitness_machine_service.py
+++ b/pycycling/fitness_machine_service.py
@@ -115,10 +115,10 @@ class FitnessMachineService:
             ftms_fitness_machine_feature_characteristic_id
         )
         return parse_all_features(message)
-    
+
     async def get_fitness_machine_feature(self) -> FitnessMachineFeature:
         return (await self.get_all_features())[0]
-    
+
     async def get_target_setting_feature(self) -> TargetSettingFeature:
         return (await self.get_all_features())[1]
 

--- a/pycycling/fitness_machine_service.py
+++ b/pycycling/fitness_machine_service.py
@@ -23,6 +23,7 @@ Finally, it modifies 'write' characteristics with some time in between:
 
 """
 
+from typing import Tuple
 from collections import namedtuple
 
 from pycycling.ftms_parsers import (
@@ -34,6 +35,7 @@ from pycycling.ftms_parsers import (
     form_ftms_control_command,
     FTMSControlPointOpCode,
     FitnessMachineFeature,
+    TargetSettingFeature,
 )
 
 # read: Supported Resistance Level Range
@@ -108,11 +110,17 @@ class FitnessMachineService:
         )
         return _parse_supported_power_range(message)
 
-    async def get_fitness_machine_feature(self) -> FitnessMachineFeature:
+    async def get_all_features(self) -> Tuple[FitnessMachineFeature, TargetSettingFeature]:
         message = await self._client.read_gatt_char(
             ftms_fitness_machine_feature_characteristic_id
         )
         return parse_all_features(message)
+    
+    async def get_fitness_machine_feature(self) -> FitnessMachineFeature:
+        return (await self.get_all_features())[0]
+    
+    async def get_target_setting_feature(self) -> TargetSettingFeature:
+        return (await self.get_all_features())[1]
 
     # === NOTIFY Characteristics ===
     # ====== Indoor Bike Data ======

--- a/pycycling/ftms_parsers/fitness_machine_feature.py
+++ b/pycycling/ftms_parsers/fitness_machine_feature.py
@@ -24,8 +24,8 @@ FitnessMachineFeature = namedtuple(
 )
 
 
-TargetSettingFeatures = namedtuple(
-    "TargetSettingFeatures",
+TargetSettingFeature = namedtuple(
+    "TargetSettingFeature",
     [
         "speed_target_setting_supported",
         "inclination_target_setting_supported",
@@ -49,7 +49,7 @@ TargetSettingFeatures = namedtuple(
 
 
 
-def parse_fitness_machine_feature(message: bytearray) -> FitnessMachineFeature:
+def parse_fitness_machine_features(message: bytearray) -> FitnessMachineFeature:
     """Bit flags are set across two message"""
     avg_speed_supported = bool(message[0] & 0b00000001)
     cadence_supported = bool(message[0] & 0b00000010)
@@ -89,7 +89,7 @@ def parse_fitness_machine_feature(message: bytearray) -> FitnessMachineFeature:
     )
 
 
-def parse_target_setting_features(message: bytearray) -> TargetSettingFeatures:
+def parse_target_setting_features(message: bytearray) -> TargetSettingFeature:
     speed_target_setting_supported = bool(message[0] & 0b00000001)
     inclination_target_setting_supported = bool(message[0] & 0b00000010)
     resistance_target_setting_supported = bool(message[0] & 0b00000100)
@@ -109,7 +109,7 @@ def parse_target_setting_features(message: bytearray) -> TargetSettingFeatures:
     spin_down_control_supported = bool(message[1] & 0b10000000)
 
     targeted_cadence_configuration_supported = bool(message[2] & 0b00000001)
-    return TargetSettingFeatures(
+    return TargetSettingFeature(
         speed_target_setting_supported,
         inclination_target_setting_supported,
         resistance_target_setting_supported,
@@ -130,4 +130,4 @@ def parse_target_setting_features(message: bytearray) -> TargetSettingFeatures:
     )
 
 def parse_all_features(message: bytearray):
-    return parse_fitness_machine_feature(message[0:4]), parse_target_setting_features(message[4:8])
+    return parse_fitness_machine_features(message[0:4]), parse_target_setting_features(message[4:8])


### PR DESCRIPTION
Fixes #48 

Changes:
+ Restore backward compatible expected behavior for `get_fitness_machine_feature` method, which in v0.4.0 was changed to return a tuple, where it was previously not a tuple. Add two convenience methods to this end.
+ Improve singular/plural naming internally.
+ Fix type annotations