### PR TITLE
Fix unexpected behaviour in _parse_hr_measurement()

### DIFF
--- a/pycycling/heart_rate_service.py
+++ b/pycycling/heart_rate_service.py
@@ -9,7 +9,8 @@ def _parse_hr_measurement(data):
     flags = data[0]
 
     is_uint16_measurement_mask = 0x01
-    is_contact_detected_mask = 0x06
+    is_contact_detected_mask = 0x02
+    is_sensor_contact_feature_supported = 0x04
     is_energy_expended_present_mask = 0x08
     is_rr_interval_present_mask = 0x10
 
@@ -19,7 +20,9 @@ def _parse_hr_measurement(data):
     energy_expended = None
 
     measurement_byte_offset = 1
-    sensor_contact = bool(flags & is_contact_detected_mask)
+
+    if flags & is_sensor_contact_feature_supported:
+        sensor_contact = bool(flags & is_contact_detected_mask)
 
     if flags & is_uint16_measurement_mask:
         bpm = int.from_bytes(data[measurement_byte_offset:measurement_byte_offset + 2], 'little')

--- a/test/test_heart_rate_service.py
+++ b/test/test_heart_rate_service.py
@@ -11,7 +11,7 @@ class TestHeartRateServiceService(unittest.TestCase):
                 0b00101010,  # bpm
             ])),
             HeartRateMeasurement(
-                sensor_contact=False,
+                sensor_contact=None,
                 bpm=42,
                 rr_interval=[],
                 energy_expended=None


### PR DESCRIPTION
In this library whenever a feature is not supported its value is reported as None. But _parse_hr_measurement() returns False if the Sensor Contact feature is not supported. To bring it inline with the library, it should return None in this case and only return False if the Sensor Contact feature is supported but no contact is detected.