### PR TITLE
use Enum value lookup

### DIFF
--- a/pycycling/cycling_power_service.py
+++ b/pycycling/cycling_power_service.py
@@ -58,10 +58,10 @@ CyclingPowerVector = namedtuple('CyclingPowerVector',
 def _parse_sensor_location(measurement):
     value = int.from_bytes(measurement, 'little')
 
-    if value >= len(SensorLocation):
-        return None
-    else:
+    try:
         return SensorLocation(value + 1)
+    except ValueError:
+        return None
 
 
 def _parse_cycling_power_feature(measurement):
@@ -83,22 +83,14 @@ def _parse_cycling_power_feature(measurement):
     span_length_adjustment_supported = bool(value & (1 << 13))
     sensor_measurement_context_value = bool(value & (1 << 14))
 
-    sensor_measurement_context = SensorMeasurementContext.force_based
-    if sensor_measurement_context_value:
-        sensor_measurement_context = SensorMeasurementContext.torque_based
+    sensor_measurement_context = SensorMeasurementContext(sensor_measurement_context_value + 1)
 
     instantaneous_measurement_direction_supported = bool(value & (1 << 15))
     factory_calibration_date_supported = bool(value & (1 << 16))
     enhanced_offset_compensation_supported = bool(value & (1 << 17))
 
-    distribute_system_support_value = (value & 0b11000000000000000000) >> 20
-    distribute_system_support = DistributeSystemSupport.unspecified
-    if distribute_system_support_value == 1:
-        distribute_system_support = DistributeSystemSupport.no_distributed_system_support
-    elif distribute_system_support_value == 2:
-        distribute_system_support = DistributeSystemSupport.distributed_system_support
-    elif distribute_system_support_value == 3:
-        distribute_system_support = DistributeSystemSupport.rfu
+    distribute_system_support_value = (value & 0b11000000000000000000) >> 18
+    distribute_system_support = DistributeSystemSupport(distribute_system_support_value + 1)
 
     return CyclingPowerFeature(
         pedal_power_balance_supported=pedal_power_balance_supported,
@@ -230,13 +222,7 @@ def _parse_cycling_power_vector(data):
     instantaneous_torque_array_present = bool(flags & 0b1000)
     instantaneous_measurement_direction_value = (flags & 0b110000) >> 4
 
-    instantaneous_measurement_direction = InstantaneousMeasurementDirection.unknown
-    if instantaneous_measurement_direction_value == 1:
-        instantaneous_measurement_direction = InstantaneousMeasurementDirection.tangential_component
-    elif instantaneous_measurement_direction_value == 2:
-        instantaneous_measurement_direction = InstantaneousMeasurementDirection.radial_component
-    elif instantaneous_measurement_direction_value == 3:
-        instantaneous_measurement_direction = InstantaneousMeasurementDirection.lateral_component
+    instantaneous_measurement_direction = InstantaneousMeasurementDirection(instantaneous_measurement_direction_value + 1)
 
     byte_offset = 1
     cumulative_crank_revs = None

--- a/pycycling/ftms_parsers/training_status.py
+++ b/pycycling/ftms_parsers/training_status.py
@@ -43,38 +43,8 @@ def parse_training_status(message: bytearray) -> TrainingStatusMessage:
 
     if param_exists:
         ts_byte = message[1]
-        if ts_byte == 0x00:
-            param = TrainingStatus.OTHER
-        elif ts_byte == 0x01:
-            param = TrainingStatus.IDLE
-        elif ts_byte == 0x02:
-            param = TrainingStatus.WARMING_UP
-        elif ts_byte == 0x03:
-            param = TrainingStatus.LOW_INTENSITY_INTERVAL
-        elif ts_byte == 0x04:
-            param = TrainingStatus.HIGH_INTENSITY_INTERVAL
-        elif ts_byte == 0x05:
-            param = TrainingStatus.RECOVERY_INTERVAL
-        elif ts_byte == 0x06:
-            param = TrainingStatus.ISOMETRIC
-        elif ts_byte == 0x07:
-            param = TrainingStatus.HEART_RATE_CONTROL
-        elif ts_byte == 0x08:
-            param = TrainingStatus.FITNESS_TEST
-        elif ts_byte == 0x09:
-            param = TrainingStatus.SPEED_OUTSIDE_CONTROL_REGION_LOW
-        elif ts_byte == 0x0A:
-            param = TrainingStatus.SPEED_OUTSIDE_CONTROL_REGION_HIGH
-        elif ts_byte == 0x0B:
-            param = TrainingStatus.COOL_DOWN
-        elif ts_byte == 0x0C:
-            param = TrainingStatus.WATT_CONTROL
-        elif ts_byte == 0x0D:
-            param = TrainingStatus.MANUAL_MODE
-        elif ts_byte == 0x0E:
-            param = TrainingStatus.PRE_WORKOUT
-        elif ts_byte == 0x0F:
-            param = TrainingStatus.POST_WORKOUT
-        elif ts_byte == 0x10:
-            param = TrainingStatus.RESERVED
+        try:
+            param = TrainingStatus(ts_byte)
+        except ValueError:
+            pass
     return TrainingStatusMessage(param, string)

--- a/pycycling/tacx_trainer_control.py
+++ b/pycycling/tacx_trainer_control.py
@@ -72,7 +72,7 @@ tacx_uart_tx_id = '6e40fec2-b5a3-f393-e0a9-e50e24dcca9e'
 
 EquipmentType = Enum('EquipmentType', 'treadmill elliptical reserved rower climber nordic_skier trainer')
 
-FEState = Enum('FEState', 'reserved ready in_use finished')
+FEState = Enum('FEState', 'reserved asleep ready in_use finished')
 
 TargetPowerLimit = Enum('TargetPowerLimit',
                         'operating_at_target_or_no_target_set user_speed_too_low user_speed_too_high limit_reached')
@@ -319,38 +319,19 @@ class TacxTrainerControl:
 
     @staticmethod
     def _equipment_type_from_code(equipment_type_code):
-        equipment_type = None
-        if equipment_type_code == 19:
-            equipment_type = EquipmentType.treadmill
-        elif equipment_type_code == 20:
-            equipment_type = EquipmentType.elliptical
-        elif equipment_type_code == 21:
-            equipment_type = EquipmentType.reserved
-        elif equipment_type_code == 22:
-            equipment_type = EquipmentType.rower
-        elif equipment_type_code == 23:
-            equipment_type = EquipmentType.climber
-        elif equipment_type_code == 24:
-            equipment_type = EquipmentType.nordic_skier
-        elif equipment_type_code == 25:
-            equipment_type = EquipmentType.trainer
-        return equipment_type
+        try:
+            return EquipmentType(equipment_type_code - 18)
+        except ValueError:
+            return None
 
     @staticmethod
     def _parse_fe_state_nibble(fe_state_nibble):
         lap_toggle = bool(fe_state_nibble & 0x8)
         code = fe_state_nibble & 0x7
-        fe_state = None
-        if code == 0:
-            fe_state = FEState.reserved
-        elif code == 1:
-            fe_state = FEState.asleep
-        elif code == 2:
-            fe_state = FEState.ready
-        elif code == 3:
-            fe_state = FEState.in_use
-        elif code == 4:
-            fe_state = FEState.finished
+        try:
+            fe_state = FEState(code + 1)
+        except ValueError:
+            fe_state = None
         return fe_state, lap_toggle
 
     def _specific_trainer_data_page_handler(self, message_data):
@@ -376,18 +357,13 @@ class TacxTrainerControl:
         user_configuration_required = bool(trainer_status_flags & 0x4)
 
         fe_state, lap_toggle = self._parse_fe_state_nibble((message_data[7] >> 4))
-        target_power_limits = None
 
         flags = message_data[7] & 0x7
 
-        if flags == 0:
-            target_power_limits = TargetPowerLimit.operating_at_target_or_no_target_set
-        elif flags == 1:
-            target_power_limits = TargetPowerLimit.user_speed_too_low
-        elif flags == 2:
-            target_power_limits = TargetPowerLimit.user_speed_too_high
-        elif flags == 3:
-            target_power_limits = TargetPowerLimit.limit_reached
+        try:
+            target_power_limits = TargetPowerLimit(flags + 1)
+        except ValueError:
+            target_power_limits = None
 
         if self._specific_trainer_data_page_callback is not None:
             self._specific_trainer_data_page_callback(


### PR DESCRIPTION
use Enum value lookup to make the code more readable and less error prone.
This does not change the behaviour.

This PR also includes 2 bug fixes:
1. This
`distribute_system_support_value = (value & 0b11000000000000000000) >> 20`
always evaluates to 0, since
`(value & 0b11000000000000000000) >> 20 == ((value >> 20) & (0b11000000000000000000 >> 20)) == ((value >> 20) & 0) == 0`. So i replaced it with `distribute_system_support_value = (value & 0b11000000000000000000) >> 18`.
2. The definition of the FEState Enum didn't include `FEState.asleep ` but `_parse_fe_state_nibble()` used it. So i assumed that it should be a member of the Enum and added it.
